### PR TITLE
.kbd & .code

### DIFF
--- a/css/classes.css
+++ b/css/classes.css
@@ -1034,6 +1034,17 @@ This file contains DLx styles that need to be explicitly specified using classes
 .italic {
   font-style: italic;
 }
+.kbd {
+  background-color: #f7f7f7;
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  color: #444;
+  padding: .25em .5em;
+  text-align: center;
+  text-shadow: 0 1px 0 #fff;
+  box-shadow: 0px 2px 0 #bbb, 0 3px 1px #999, 0 3px 0 #bbb, inset 0 1px 1px #fff, inset 0 -1px 3px #ccc;
+}
 .label {
   align-items: center;
   flex-direction: row;

--- a/css/classes.css
+++ b/css/classes.css
@@ -529,10 +529,11 @@ This file contains DLx styles that need to be explicitly specified using classes
   font-style: italic;
 }
 .code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;

--- a/css/dlx.css
+++ b/css/dlx.css
@@ -1311,6 +1311,17 @@ This file contains DLx styles that need to be explicitly specified using classes
 .italic {
   font-style: italic;
 }
+.kbd {
+  background-color: #f7f7f7;
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  color: #444;
+  padding: .25em .5em;
+  text-align: center;
+  text-shadow: 0 1px 0 #fff;
+  box-shadow: 0px 2px 0 #bbb, 0 3px 1px #999, 0 3px 0 #bbb, inset 0 1px 1px #fff, inset 0 -1px 3px #ccc;
+}
 .label {
   align-items: center;
   flex-direction: row;

--- a/css/dlx.css
+++ b/css/dlx.css
@@ -806,10 +806,11 @@ This file contains DLx styles that need to be explicitly specified using classes
   font-style: italic;
 }
 .code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;

--- a/css/global.css
+++ b/css/global.css
@@ -1314,6 +1314,17 @@ This file contains DLx styles that need to be explicitly specified using classes
 .italic {
   font-style: italic;
 }
+.kbd {
+  background-color: #f7f7f7;
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  color: #444;
+  padding: .25em .5em;
+  text-align: center;
+  text-shadow: 0 1px 0 #fff;
+  box-shadow: 0px 2px 0 #bbb, 0 3px 1px #999, 0 3px 0 #bbb, inset 0 1px 1px #fff, inset 0 -1px 3px #ccc;
+}
 .label {
   align-items: center;
   flex-direction: row;

--- a/css/global.css
+++ b/css/global.css
@@ -809,10 +809,11 @@ This file contains DLx styles that need to be explicitly specified using classes
   font-style: italic;
 }
 .code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;
@@ -1986,10 +1987,11 @@ cite {
   font-style: italic;
 }
 code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;

--- a/css/patterns.css
+++ b/css/patterns.css
@@ -1314,6 +1314,17 @@ This file contains DLx styles that need to be explicitly specified using classes
 .italic {
   font-style: italic;
 }
+.kbd {
+  background-color: #f7f7f7;
+  background-image: linear-gradient(to top, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0));
+  border: 1px solid #bbb;
+  border-radius: 6px;
+  color: #444;
+  padding: .25em .5em;
+  text-align: center;
+  text-shadow: 0 1px 0 #fff;
+  box-shadow: 0px 2px 0 #bbb, 0 3px 1px #999, 0 3px 0 #bbb, inset 0 1px 1px #fff, inset 0 -1px 3px #ccc;
+}
 .label {
   align-items: center;
   flex-direction: row;

--- a/css/patterns.css
+++ b/css/patterns.css
@@ -809,10 +809,11 @@ This file contains DLx styles that need to be explicitly specified using classes
   font-style: italic;
 }
 .code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;
@@ -1986,10 +1987,11 @@ cite {
   font-style: italic;
 }
 code {
-  background-color: #F5F2F0;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;

--- a/data/patterns.json
+++ b/data/patterns.json
@@ -64,6 +64,10 @@
     "description": "Used for general italic styling. Other more semantic classes should be preferred over this one when possible."
   },
 
+  "kbd": {
+    "description": "Used for indicating keyboard input."
+  },
+
   "label": {
     "description": "Label elements. If the text inside the element is wrapped in a <code>&lt;span&gt;</code> element, that text will be styled as well."
   },

--- a/examples/kbd.hbs
+++ b/examples/kbd.hbs
@@ -1,0 +1,1 @@
+<p>This is an example of a <kbd class=kbd>keyboard input</kbd>. Press <kbd class=kbd>Ctrl + S</kbd> to save.</p>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
         <option value=typography>Typography</option>
         <option value=icons>Icons</option>
         <option value=patterns>Patterns</option>
-        <option value=abbr-pattern>abbr</option><option value=bulleted-pattern>bulleted</option><option value=button-pattern>button</option><option value=cite-pattern>cite</option><option value=code-pattern>code</option><option value=dfn-pattern>dfn</option><option value=em-pattern>em</option><option value=field-pattern>field</option><option value=fieldset-pattern>fieldset</option><option value=hanging-pattern>hanging</option><option value=h-minor-pattern>h-minor</option><option value=h-section-pattern>h-section</option><option value=h-subsection-pattern>h-subsection</option><option value=h-subsubsection-pattern>h-subsubsection</option><option value=input-pattern>input</option><option value=italic-pattern>italic</option><option value=label-pattern>label</option><option value=link-pattern>link</option><option value=link-white-pattern>link-white</option><option value=nav-pattern>nav</option><option value=numbered-pattern>numbered</option><option value=orthographic-pattern>orthographic</option><option value=page-title-pattern>page-title</option><option value=phonemic-pattern>phonemic</option><option value=phonetic-pattern>phonetic</option><option value=reference-list-pattern>reference-list</option><option value=select-pattern>select</option><option value=strong-pattern>strong</option><option value=textarea-pattern>textarea</option><option value=tooltip-pattern>tooltip</option><option value=unicode-pattern>unicode</option>
+        <option value=abbr-pattern>abbr</option><option value=bulleted-pattern>bulleted</option><option value=button-pattern>button</option><option value=cite-pattern>cite</option><option value=code-pattern>code</option><option value=dfn-pattern>dfn</option><option value=em-pattern>em</option><option value=field-pattern>field</option><option value=fieldset-pattern>fieldset</option><option value=hanging-pattern>hanging</option><option value=h-minor-pattern>h-minor</option><option value=h-section-pattern>h-section</option><option value=h-subsection-pattern>h-subsection</option><option value=h-subsubsection-pattern>h-subsubsection</option><option value=input-pattern>input</option><option value=italic-pattern>italic</option><option value=kbd-pattern>kbd</option><option value=label-pattern>label</option><option value=link-pattern>link</option><option value=link-white-pattern>link-white</option><option value=nav-pattern>nav</option><option value=numbered-pattern>numbered</option><option value=orthographic-pattern>orthographic</option><option value=page-title-pattern>page-title</option><option value=phonemic-pattern>phonemic</option><option value=phonetic-pattern>phonetic</option><option value=reference-list-pattern>reference-list</option><option value=select-pattern>select</option><option value=strong-pattern>strong</option><option value=textarea-pattern>textarea</option><option value=tooltip-pattern>tooltip</option><option value=unicode-pattern>unicode</option>
       </select>
 
     </label>
@@ -901,6 +901,27 @@
           <div>
             <h1 class=h-minor>Live Example</h1>
             <div class=rendered><p>This shows an example of <i class=italic>italicized text</i>.</p>
+    </div>
+          </div>
+    
+        </section>
+        <section id=kbd-pattern class='pattern kbd-example'>
+    
+          <header>
+            <h1 class='pattern-title header-subsection'><code>kbd</code></h1>
+            <p class=pattern-description>Used for indicating keyboard input.</p>
+          </header>
+    
+          <div>
+            <h1 class=h-minor>Example Markup</h1>
+            <pre><code class=markup>
+    &lt;p&gt;This is an example of a &lt;kbd class&#x3D;kbd&gt;keyboard input&lt;/kbd&gt;. Press &lt;kbd class&#x3D;kbd&gt;Ctrl + S&lt;/kbd&gt; to save.&lt;/p&gt;
+    </code></pre>
+          </div>
+    
+          <div>
+            <h1 class=h-minor>Live Example</h1>
+            <div class=rendered><p>This is an example of a <kbd class=kbd>keyboard input</kbd>. Press <kbd class=kbd>Ctrl + S</kbd> to save.</p>
     </div>
           </div>
     

--- a/less/classes.less
+++ b/less/classes.less
@@ -191,10 +191,11 @@ This file contains DLx styles that need to be explicitly specified using classes
 }
 
 .code {
-  .gray-background;
+  background-color: #fafafa;
   border: 1px solid black;
   border-radius: 5px;
-  font-family: 'Consolas', 'Fira Mono', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
+  color: #383a42;
+  font-family: 'Fira Mono', 'Consolas', 'Monaco', 'DejaVu Mono', 'Courier New', monospace;
   font-size: 0.75em;
   font-style: normal;
   overflow-x: auto;

--- a/less/classes.less
+++ b/less/classes.less
@@ -351,6 +351,25 @@ This file contains DLx styles that need to be explicitly specified using classes
   font-style: italic;
 }
 
+.kbd {
+
+  background-color: #f7f7f7;
+  background-image: linear-gradient(to top, rgba(0,0,0,0.1), rgba(0,0,0,0));
+  border: 1px solid #bbb;
+  border-radius: 6px;
+	color: #444;
+  padding: .25em .5em;
+	text-align: center;
+	text-shadow: 0 1px 0 #fff;
+
+  box-shadow: 0px 2px 0 #bbb,
+    0 3px 1px #999,
+    0 3px 0 #bbb,
+    inset 0 1px 1px #fff,
+    inset 0 -1px 3px #ccc;
+
+}
+
 .label {
 
   align-items: center;

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "exec": "yarn run hbs & yarn run upload & yarn run less",
+  "exec": "yarn run hbs & yarn run upload & yarn run less & yarn run css",
   "ext": "hbs js json less",
   "ignore": []
 }


### PR DESCRIPTION
- adds a `.kbd` class
- minor improvements to `.code` class (styling now consistent with atom-one-light theme; use Fira Mono font by default)

closes #23 