### PR TITLE
create issue to update date in license on a yearly basis

### DIFF
--- a/.github/PRIVATE_ISSUE_TEMPLATE/update-year.md
+++ b/.github/PRIVATE_ISSUE_TEMPLATE/update-year.md
@@ -1,0 +1,9 @@
+---
+title: update year in documentation
+labels: docs
+---
+Update the year in the documentation to {{ date | YYYY }}.
+
+- [ ] license
+- [ ] general readme
+- [ ] developer readme

--- a/.github/workflows/year.yml
+++ b/.github/workflows/year.yml
@@ -1,0 +1,16 @@
+name: year
+
+on:
+  schedule:
+    - cron: '0 0 1 1 *' # run yearly on Jan 1
+
+jobs:
+  open-issue:
+    steps:
+
+      - name: create issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/PRIVATE_ISSUE_TEMPLATE/update-year.md


### PR DESCRIPTION
This PR adds a GitHub Action to create an issue on a yearly basis for updating the date in the license.

closes #139